### PR TITLE
Update to modern Dart syntax and lints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Files and directories created by pub
 .packages
 .pub/
+.dart_tool/
 build/
 packages
 # Remove the following pattern if you wish to check in your lock file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0 (2022-11-12)
+
+- Update to modern Dart syntax and lints.
+- Moved to shelf_router instead of shelf_route as the latter is deprecated.
+
 ## 0.1.0
 
 - Initial version

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/example/shelf_eventsource_example.dart
+++ b/example/shelf_eventsource_example.dart
@@ -1,7 +1,7 @@
 import "dart:async";
 
 import "package:shelf/shelf_io.dart" as io;
-import "package:shelf_route/shelf_route.dart" as routing;
+import "package:shelf_router/shelf_router.dart" as routing;
 
 import "package:eventsource/publisher.dart";
 import "package:shelf_eventsource/shelf_eventsource.dart";
@@ -9,7 +9,7 @@ import "package:shelf_eventsource/shelf_eventsource.dart";
 main() {
   // create the publisher object that will manage event publishing to
   // subscribers
-  EventSourcePublisher publisher = new EventSourcePublisher(cacheCapacity: 100);
+  EventSourcePublisher publisher = EventSourcePublisher(cacheCapacity: 100);
 
   // generate some dummy events
   generateEvents(publisher);
@@ -21,28 +21,27 @@ main() {
       eventSourceHandler(publisher, channel: "mychannel", gzip: true);
 
   // create a router to serve the different event sources
-  var router = routing.router();
+  var router = routing.Router();
   router.get("/events", handler);
   router.get("/mychannel", channelHandler);
 
   // serve localhost with our router
-  io.serve(router.handler, "localhost", 8080);
+  io.serve(router, "localhost", 8080);
 }
 
 generateEvents(publisher) {
   int id = 0;
-  new Timer.periodic(const Duration(seconds: 1), (timer) {
+  Timer.periodic(const Duration(seconds: 1), (timer) {
     // publish an event on the default channel
-    publisher
-        .add(new Event.message(id: "$id", data: "Always the same message?"));
+    publisher.add(Event.message(id: "$id", data: "Always the same message?"));
     // publish event in a channel
     publisher.add(
-        new Event.message(id: "$id", data: "Mychannel Message"), ["mychannel"]);
+        Event.message(id: "$id", data: "Mychannel Message"), ["mychannel"]);
     if (id == 25) {
       timer.cancel();
       // broadcast last message to both channels and close them
       publisher.add(
-          new Event(event: "goodbye", data: "Goodbye all!"), ["", "mychannel"]);
+          Event(event: "goodbye", data: "Goodbye all!"), ["", "mychannel"]);
       publisher.closeAll();
     }
   });

--- a/lib/shelf_eventsource.dart
+++ b/lib/shelf_eventsource.dart
@@ -1,28 +1,27 @@
 library shelf_eventsource;
 
-import "dart:convert";
+import 'dart:convert';
 
 import "package:eventsource/publisher.dart";
 import "package:eventsource/src/encoder.dart";
 import "package:shelf/shelf.dart";
-import 'package:stream_channel/stream_channel.dart';
 
 /// Create a shelf handler for the specified channel.
 /// This handler can be passed to the [shelf.serve] method.
 Handler eventSourceHandler(EventSourcePublisher publisher,
-    {String channel: "", bool gzip: false}) {
+    {String channel = "", bool gzip = false}) {
   // define the handler
   Response shelfHandler(Request request) {
     if (request.method != "GET") {
-      return new Response.notFound(null);
+      return Response.notFound(null);
     }
 
     if (request.headers["Accept"] != "text/event-stream") {
-      return new Response(400, body: "Bad Request");
+      return Response(400, body: "Bad Request");
     }
 
     if (!request.canHijack) {
-      throw new ArgumentError("eventSourceHandler may only be used with a "
+      throw ArgumentError("eventSourceHandler may only be used with a "
           "server that supports request hijacking.");
     }
 
@@ -32,10 +31,9 @@ Handler eventSourceHandler(EventSourcePublisher publisher,
 
     // hijack the raw underlying channel
     request.hijack((untypedChannel) {
-      var socketChannel =
-          (untypedChannel as StreamChannel).cast/*<List<int>>*/();
+      var socketChannel = (untypedChannel).cast<List<int>>();
       // create a regular UTF8 sink to write headers
-      var sink = UTF8.encoder.startChunkedConversion(socketChannel.sink);
+      var sink = utf8.encoder.startChunkedConversion(socketChannel.sink);
       // write headers
       sink.add("HTTP/1.1 200 OK\r\n"
           "Content-Type: text/event-stream; charset=utf-8\r\n"
@@ -45,9 +43,9 @@ Handler eventSourceHandler(EventSourcePublisher publisher,
       sink.add("\r\n");
 
       // create encoder for this connection
-      var encodedSink = new EventSourceEncoder(compressed: useGzip)
+      var encodedSink = EventSourceEncoder(compressed: useGzip)
           .startChunkedConversion(socketChannel.sink);
-      
+
       // initialize the new subscription
       publisher.newSubscription(
           onEvent: encodedSink.add,
@@ -58,8 +56,6 @@ Handler eventSourceHandler(EventSourcePublisher publisher,
 
     // [request.hijack] is guaranteed to throw a [HijackException], so we'll
     // never get here.
-    assert(false);
-    return null;
   }
 
   return shelfHandler;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,18 @@
 name: shelf_eventsource
 description: A shelf handler for Server-Sent Events (SSE).
-version: 0.2.0-rc1
-author: Steven Roose <stevenroose@gmail.com>
-homepage: https://github.com/stevenroose/dart-shelf_eventsource
+version: 0.3.0
+repository: https://github.com/stevenroose/dart-shelf_eventsource
 
 environment:
-  sdk: ">=1.0.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  eventsource: ">=0.1.0 <0.3.0"
-  shelf: ">=0.6.5 <0.8.0"
-  stream_channel: ">=1.5.0 <2.0.0"
+  eventsource: ^0.4.0
+  shelf: ^1.4.0
+  stream_channel: ^2.1.1
 
 dev_dependencies:
-  test: ">=0.12.0 <2.0.0"
+  lints: ^2.0.1
+  test: ^1.22.0
   # for the examples:
-  #shelf_route: ">=0.13.0 <0.15.0"
+  shelf_router: ^1.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   eventsource: ^0.4.0
   shelf: ^1.4.0
-  stream_channel: ^2.1.1
+  stream_channel: ^2.1.0
 
 dev_dependencies:
   lints: ^2.0.1


### PR DESCRIPTION
Also changed to use shelf_router instead of shelf_route since the latter is deprecated.